### PR TITLE
Change component value to false

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
 	"name": "LawSoc_VI_UAT",
-	"component": true,
+	"component": false,
 	"license_url": null,
 	"about_url": null,
 	"authors": null,


### PR DESCRIPTION
The component value should be set to false as this is a theme. Setting it to true will make it a component and place it in the component section of the customise tab in the community.

A theme and component are very similar in discourse (you can get them both to do essentially the same things), the main difference being that a theme can be set by itself but a component must be assigned to a theme.